### PR TITLE
Add basic unit tests for service modules

### DIFF
--- a/src/tests/unit/audioCounter.test.ts
+++ b/src/tests/unit/audioCounter.test.ts
@@ -1,0 +1,17 @@
+import { incrementAudioCount, resetAudioCount, getAudioCount } from '../../services/audioCounter';
+
+describe('audioCounter', () => {
+  it('increments and retrieves count', () => {
+    resetAudioCount('123');
+    expect(getAudioCount('123')).toBe(0);
+    incrementAudioCount('123');
+    incrementAudioCount('123');
+    expect(getAudioCount('123')).toBe(2);
+  });
+
+  it('resets count', () => {
+    incrementAudioCount('321');
+    resetAudioCount('321');
+    expect(getAudioCount('321')).toBe(0);
+  });
+});

--- a/src/tests/unit/audioPreferenceAnalyzer.test.ts
+++ b/src/tests/unit/audioPreferenceAnalyzer.test.ts
@@ -1,0 +1,16 @@
+import { clientePrefereAudio } from '../../services/audioPreferenceAnalyzer';
+import * as audioCounter from '../../services/audioCounter';
+
+jest.mock('../../services/audioCounter');
+
+describe('clientePrefereAudio', () => {
+  it('returns true when audio count > 0', () => {
+    (audioCounter.getAudioCount as jest.Mock).mockReturnValue(1);
+    expect(clientePrefereAudio('123')).toBe(true);
+  });
+
+  it('returns false when audio count is 0', () => {
+    (audioCounter.getAudioCount as jest.Mock).mockReturnValue(0);
+    expect(clientePrefereAudio('123')).toBe(false);
+  });
+});

--- a/src/tests/unit/checklistFechamento.test.ts
+++ b/src/tests/unit/checklistFechamento.test.ts
@@ -1,0 +1,23 @@
+import { checklistFechamento } from '../../services/checklistFechamento';
+
+const valid = {
+  address: { value: 'Rua A', valid: true },
+  payment_method: { value: 'pix', valid: true },
+  schedule_time: { value: '10h', valid: true },
+  confirmacao: { value: 'sim', valid: true }
+};
+
+describe('checklistFechamento', () => {
+  it('approves when all fields valid', () => {
+    const result = checklistFechamento(valid as any);
+    expect(result.aprovado).toBe(true);
+    expect(result.faltando).toHaveLength(0);
+  });
+
+  it('fails when a field is missing', () => {
+    const fields = { ...valid, schedule_time: { value: null, valid: false } } as any;
+    const result = checklistFechamento(fields);
+    expect(result.aprovado).toBe(false);
+    expect(result.faltando).toContain('schedule_time');
+  });
+});

--- a/src/tests/unit/clientProfileRepository.test.ts
+++ b/src/tests/unit/clientProfileRepository.test.ts
@@ -1,0 +1,12 @@
+import { getAnalyzedProfile } from '../../services/clientProfileRepository';
+import { botPersona } from '../../persona/botPersona';
+
+describe('getAnalyzedProfile', () => {
+  it('maps botPersona style to perfil cliente', () => {
+    const perfil = getAnalyzedProfile('999');
+    expect(perfil.formalidade).toBe(botPersona.estiloDeFala.formalidade);
+    expect(perfil.emojis).toBe(botPersona.estiloDeFala.emojis);
+    const fala = botPersona.estiloDeFala.frasesCurtas ? 'fala pouco' : 'fala muito';
+    expect(perfil.fala).toBe(fala);
+  });
+});

--- a/src/tests/unit/levantamentoAdaptativo.test.ts
+++ b/src/tests/unit/levantamentoAdaptativo.test.ts
@@ -1,0 +1,16 @@
+import { decidirModoLevantamento } from '../../services/levantamentoAdaptativo';
+import * as objectionMonitor from '../../services/objectionMonitor';
+
+jest.mock('../../services/objectionMonitor');
+
+describe('decidirModoLevantamento', () => {
+  it('returns leve when objection none', async () => {
+    (objectionMonitor.analisarObjeçõesIA as jest.Mock).mockResolvedValue('nenhuma');
+    await expect(decidirModoLevantamento(['oi'])).resolves.toBe('leve');
+  });
+
+  it('returns profundo when objection moderate', async () => {
+    (objectionMonitor.analisarObjeçõesIA as jest.Mock).mockResolvedValue('moderada');
+    await expect(decidirModoLevantamento(['oi'])).resolves.toBe('profundo');
+  });
+});

--- a/src/tests/unit/metaPorEtapa.test.ts
+++ b/src/tests/unit/metaPorEtapa.test.ts
@@ -1,0 +1,11 @@
+import { getMetasDaEtapa, metasPorEtapa } from '../../services/metaPorEtapa';
+
+describe('getMetasDaEtapa', () => {
+  it('returns metas for known etapa', () => {
+    expect(getMetasDaEtapa('abordagem')).toEqual(metasPorEtapa.abordagem);
+  });
+
+  it('returns empty array for unknown etapa', () => {
+    expect(getMetasDaEtapa('desconhecida' as any)).toEqual([]);
+  });
+});

--- a/src/tests/unit/servicesImport.test.ts
+++ b/src/tests/unit/servicesImport.test.ts
@@ -1,0 +1,33 @@
+const services = [
+  'ExtractionService',
+  'PromptService',
+  'StateService',
+  'analyzeClientProfile',
+  'audioCounter',
+  'audioPreferenceAnalyzer',
+  'audioService',
+  'checklistFechamento',
+  'clientProfileRepository',
+  'clientRepository',
+  'contextMemory',
+  'dataExtractor',
+  'dynamicClientMonitor',
+  'intentFallback',
+  'interactionMongoService',
+  'levantamentoAdaptativo',
+  'metaPorEtapa',
+  'objectionMonitor',
+  'reengagementService',
+  'registrarAuditoriaIA',
+  'resumoDoHistorico',
+  'validadorMultiplos',
+  'verificadorContradicoes',
+  'verificadorPropostaNegociacao',
+  'conversationManager/index'
+];
+
+describe('service module imports', () => {
+  it.each(services)('%s loads without error', async (name) => {
+    await expect(import(`../../services/${name}`)).resolves.toBeDefined();
+  });
+});

--- a/src/tests/unit/verificadorContradicoes.test.ts
+++ b/src/tests/unit/verificadorContradicoes.test.ts
@@ -1,0 +1,52 @@
+import { verificarContradicoes } from '../../services/verificadorContradicoes';
+import type { Client } from '../../types/Client';
+
+describe('verificarContradicoes', () => {
+  const baseClient: Client = {
+    id: 1,
+    phone: '123',
+    produto_id: null,
+    current_state: null,
+    retries: null,
+    has_greeted: null,
+    name: null,
+    needs: null,
+    budget: null,
+    negotiated_price: null,
+    address: null,
+    payment_method: null,
+    schedule_time: null,
+    feedback: null,
+    reactivation_reason: null,
+    attempted_solutions: null,
+    expectations: null,
+    urgency_level: null,
+    client_stage: null,
+    objection_type: null,
+    purchase_intent: null,
+    scheduling_preference: null,
+    disponibilidade: null,
+    motivo_objeção: null,
+    alternativa: null,
+    desconto: null,
+    forma_pagamento: null,
+    confirmacao: null,
+    indicacao: null,
+    state: '',
+    last_interaction: new Date(),
+    created_at: new Date(),
+    updated_at: new Date()
+  };
+
+  it('detects payment method missing when purchase intent is yes', () => {
+    const client = { ...baseClient, purchase_intent: 'sim', payment_method: null };
+    const result = verificarContradicoes(client, 'negociacao');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('detects low budget', () => {
+    const client = { ...baseClient, budget: '100' };
+    const result = verificarContradicoes(client, 'proposta');
+    expect(result.some(r => r.includes('Orçamento'))).toBe(true);
+  });
+});

--- a/src/tests/unit/verificadorPropostaNegociacao.test.ts
+++ b/src/tests/unit/verificadorPropostaNegociacao.test.ts
@@ -1,0 +1,37 @@
+import { verificadorPropostaNegociacao } from '../../services/verificadorPropostaNegociacao';
+import * as logs from '../../repositories/mongo/logsEstrategia.mongo';
+
+jest.mock('../../repositories/mongo/logsEstrategia.mongo');
+
+describe('verificadorPropostaNegociacao', () => {
+  it('suggests retry with higher temperature for weak response', async () => {
+    const res = await verificadorPropostaNegociacao({
+      textoGerado: 'ok',
+      etapaAtual: 'negociacao',
+      temperaturaAnterior: 0.5,
+      phone: '1'
+    });
+    expect(res.deveRefazerComMaisTemperatura).toBe(true);
+    expect(res.novaTemperatura).toBeGreaterThan(0.5);
+  });
+
+  it('does not retry when contains keyword', async () => {
+    const res = await verificadorPropostaNegociacao({
+      textoGerado: 'Temos um desconto especial',
+      etapaAtual: 'negociacao',
+      temperaturaAnterior: 0.5,
+      phone: '1'
+    });
+    expect(res.deveRefazerComMaisTemperatura).toBe(false);
+  });
+
+  it('bypasses when etapa not negociacao', async () => {
+    const res = await verificadorPropostaNegociacao({
+      textoGerado: 'ok',
+      etapaAtual: 'proposta',
+      temperaturaAnterior: 0.5,
+      phone: '1'
+    });
+    expect(res.deveRefazerComMaisTemperatura).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add initial unit tests for several service modules
- cover utilities like `audioCounter`, `metaPorEtapa` and more
- ensure all service files load via `servicesImport.test.ts`

## Testing
- `npx jest src/tests/unit --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_684082a42d2c8320b41d5f11e5d3ea3c